### PR TITLE
Fix GitHub Pages blank site by setting router basename

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,7 +6,7 @@ import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <App />
     </BrowserRouter>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- Ensure React Router uses the correct base path on GitHub Pages by setting `basename` on `BrowserRouter`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `GITHUB_REPOSITORY='example/SanAndreasCheats' npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ae796f8e083259cdcbefb6d3ba538