### PR TITLE
Serve app from relative base for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/cj.svg" />
+    <link rel="icon" type="image/svg+xml" href="./cj.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>All You Had To Do Was Follow The Damn Cheats, CJ!</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,9 +4,11 @@ import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
+const base = new URL(document.baseURI).pathname
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={base}>
       <App />
     </BrowserRouter>
   </StrictMode>,

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -10,6 +10,7 @@ export default function Home() {
   const prevStateRef = useRef(new Map())
   const clearTimerRef = useRef(null)
   const audioRef = useRef(null)
+  const base = new URL(document.baseURI).pathname
 
   const buttonSymbols = useMemo(
     () => [
@@ -232,7 +233,7 @@ export default function Home() {
   return (
     <main className="h-screen flex flex-col items-center justify-center gap-3 bg-black text-amber-200 px-4">
       <div className="text-2xl font-semibold tracking-tight text-center">
-        <img src={'cj.svg'} alt="Sup mf" className="w-16 h-16 object-contain" />
+        <img src={`${base}cj.svg`} alt="Sup mf" className="w-16 h-16 object-contain" />
       </div>
       {matchedCheat && (
         <div key={matchedCheat.id} className="text-center cheat-pop fireworks">

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,17 +1,9 @@
-/* eslint-disable no-undef */
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-// Auto-detect base path for GitHub Pages. For user/organization sites (*.github.io), base is '/'.
-// For project sites, base is '/<repo>/'. You can override with BASE_PATH env var.
-export default defineConfig(() => {
-  const repo = process.env.GITHUB_REPOSITORY || ''
-  const repoName = repo.split('/')[1] || ''
-  const isUserSite = /\.github\.io$/i.test(repoName)
-  const base = process.env.BASE_PATH ?? (isUserSite ? '/' : repoName ? `/${repoName}/` : '/')
-  return {
-    plugins: [react()],
-    base,
-  }
+// Use a relative base so the app can be served from any subpath (e.g., GitHub Pages)
+export default defineConfig({
+  plugins: [react()],
+  base: './',
 })


### PR DESCRIPTION
## Summary
- Use relative base in Vite so built assets work on GitHub Pages
- Detect router basename from `document.baseURI` at runtime
- Load CJ icon using resolved base path to prevent 404s

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ae796f8e083259cdcbefb6d3ba538