### PR TITLE
fix(audio): remove combo hit sound from cheat match — keep only cheat_activated.mp3

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import cheatsData from '../assets/cheats_v2.json'
 import {
-  playKeyClick, playGamepadPress, playComboHit,
+  playKeyClick, playGamepadPress,
   playFailSound, playAchievementSound, playBootBeep, playBootReady,
   playResetSound, playPowerOn, isMuted, toggleMute,
   playThunder, startRainAmbient, stopRainAmbient, updateRainIntensity, playWindGust,
@@ -1116,8 +1116,6 @@ export default function Home() {
           } else {
             setComboAnim('bump')
             setTimeout(() => setComboAnim(null), 250)
-            // Extra combo hit sound at 2+
-            playComboHit(newStreak)
           }
 
           // Escalate fireworks based on combo


### PR DESCRIPTION
## Summary
Removes the synthesized Web Audio API combo hit sound () that played on streak >= 2 during cheat matches.

## Changes
- Removed  from  import
- Removed  call from the cheat match handler

## Result
Only the original  plays on every cheat match, regardless of streak level.

Closes #19